### PR TITLE
feat: Compile `clang` too

### DIFF
--- a/azure-pipelines/cmake-configure-step-template.yml
+++ b/azure-pipelines/cmake-configure-step-template.yml
@@ -10,6 +10,7 @@ steps:
       cmakeArgs:
         $(Build.SourcesDirectory)/llvm-project/llvm/
         -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory)/install/llvm
+        -DLLVM_ENABLE_PROJECTS="clang"
         -DLLVM_TARGETS_TO_BUILD="X86;AArch64"
         -DLLVM_INCLUDE_DOCS=OFF
         -DLLVM_INCLUDE_EXAMPLES=OFF


### PR DESCRIPTION
We need `clang` inside the `wasmer-engine-native` crate. Since we are likely to use our own LLVM build (we already are for Windows, and for `wasmer-python` on all platforms).

Let's try this!